### PR TITLE
Add feature post question

### DIFF
--- a/projects/02_trivia_api/starter/backend/models.py
+++ b/projects/02_trivia_api/starter/backend/models.py
@@ -47,10 +47,10 @@ class Question(db.Model):
   category_id = Column(Integer, ForeignKey('categories.id'), nullable=False, default=7)
   difficulty = Column(Integer)
 
-  def __init__(self, question, answer, category, difficulty):
+  def __init__(self, question, answer, category_id, difficulty):
     self.question = question
     self.answer = answer
-    self.category = category
+    self.category_id = category_id
     self.difficulty = difficulty
 
   def insert(self):

--- a/projects/02_trivia_api/starter/backend/test_flaskr.py
+++ b/projects/02_trivia_api/starter/backend/test_flaskr.py
@@ -23,10 +23,13 @@ class TriviaTestCase(unittest.TestCase):
         setup_db(self.app, self.database_path)
 
         self.new_qst = {
-            "question": "In which Hollywood film did Michael Jordan act?"
-            , "answer": "Space Jam"
-            , "category_id": 5
-            , "difficulty": 3
+            "question": {
+                "question": "In which Hollywood film did Michael Jordan act?"
+                , "answer": "Space Jam"
+                , "category_id": 5
+                , "difficulty": 3
+                },
+            "current_category": 1
         }
 
         # binds the app to the current context
@@ -180,11 +183,17 @@ class TriviaTestCase(unittest.TestCase):
 
     def test_015_422_post_duplicate_question(self):
         res = self.client().post('/api/questions', json=json.dumps(self.new_qst))
+        
         self.assertEqual(res.status_code, 422)
+        if res.status_code == 422:
+            responses = [rsp.decode('utf-8') for rsp in res.response]
+            self.assertIn('already present', responses[0])
 
     def test_016_400_post_question_without_answer(self):
         q = {
-            "question": "In which Hollywood film did Michael Jordan act?"
+            "question": { 
+                "question": "In which Hollywood film did Michael Jordan act?"
+            }
         }
         res = self.client().post(
             '/api/questions', 

--- a/projects/02_trivia_api/starter/backend/test_flaskr.py
+++ b/projects/02_trivia_api/starter/backend/test_flaskr.py
@@ -12,6 +12,7 @@ from psycopg2.errors import UndefinedColumn
 
 class TriviaTestCase(unittest.TestCase):
     """This class represents the trivia test case"""
+    
 
     def setUp(self):
         """Define test variables and initialize app."""
@@ -20,6 +21,13 @@ class TriviaTestCase(unittest.TestCase):
 
         self.database_path = database_path.replace('trivia', 'trivia_test')
         setup_db(self.app, self.database_path)
+
+        self.new_qst = {
+            "question": "In which Hollywood film did Michael Jordan act?"
+            , "answer": "Space Jam"
+            , "category_id": 5
+            , "difficulty": 3
+        }
 
         # binds the app to the current context
         with self.app.app_context():
@@ -35,18 +43,18 @@ class TriviaTestCase(unittest.TestCase):
     TODO
     Write at least one test for each test for successful operation and for expected errors.
     """
-    def test_get_homepage(self):
+    def test_001_get_homepage(self):
         res = self.client().get('/')
         
         self.assertEqual(res.status_code, 200)
         self.assertIn(b'Hello, World!', res.data)
-    def test_405_post_homepage(self):
+    def test_002_405_post_homepage(self):
         res = self.client().post('/', json={'question': 'Is this working?'})
         
         self.assertEqual(res.status_code, 405)
         self.assertIn(b'not allowed', res.data)
 
-    def test_select_questions(self):
+    def test_003_select_questions(self):
         stmt_sel_all_questions = text('select * from questions;')
         with self.app.app_context():           
             result = self.db.engine.execute(stmt_sel_all_questions)
@@ -55,7 +63,7 @@ class TriviaTestCase(unittest.TestCase):
         self.assertTrue(rows)
         if rows:
             self.assertEqual(rows[0][0], int(5))
-    def test_column_category_name(self):
+    def test_004_column_category_name(self):
         def get_category_name_or_err_code():
             stmt_sel_name_categories = text('select name from categories;')
             with self.app.app_context():
@@ -70,7 +78,7 @@ class TriviaTestCase(unittest.TestCase):
         self.assertEqual('42703',get_category_name_or_err_code())
         #Error codes: https://www.psycopg.org/docs/errors.html#sqlstate-exception-classes
         
-    def test_select_qst_with_cat(self):
+    def test_005_select_qst_with_cat(self):
         sel_stmnt = text("""
         SELECT
             q.id, q.question, q.category_id, c.id, c.type
@@ -90,8 +98,8 @@ class TriviaTestCase(unittest.TestCase):
         self.assertIsNotNone(q_result)
         if q_result:
             rows = [row for row in q_result]
-            self.assertEqual(len(rows), 19)
-    def test_select_qst_where_cat_none(self):
+            self.assertEqual(rows[0][0], 5)
+    def test_006_select_qst_where_cat_none(self):
         sel_stmnt = text("""
         SELECT q.id, q.question
         FROM questions as q
@@ -111,18 +119,18 @@ class TriviaTestCase(unittest.TestCase):
             rows = [row for row in q_result]
             self.assertEqual(len(rows), 0)
 
-    def test_get_all_questions(self):
+    def test_007_get_all_questions(self):
         res = self.client().get('/api/questions')
         self.assertEqual(res.status_code, 200)
 
         if res.status_code == 200:
             data = json.loads(res.data)
             self.assertEqual(data['questions'][0]['id'], 2)
-    def test_404_get_all_questions(self):
+    def test_008_404_get_all_questions(self):
         res = self.client().get('/questions')
         self.assertEqual(res.status_code, 404)
     
-    def test_pagination(self):
+    def test_009_pagination(self):
         res = self.client().get('/api/questions')
         self.assertEqual(res.status_code, 200)
         if res.status_code == 200:
@@ -130,7 +138,7 @@ class TriviaTestCase(unittest.TestCase):
             self.assertLessEqual(len(data['questions']), QUESTIONS_PER_PAGE)
             self.assertGreaterEqual(data['total_questions'], QUESTIONS_PER_PAGE)
 
-    def test_get_all_questions_of_cat_1(self):
+    def test_010_get_all_questions_of_cat_1(self):
         category_id = 1
         res = self.client().get('/api/questions/categories/' + str(category_id))
         self.assertEqual(res.status_code, 200)
@@ -143,12 +151,12 @@ class TriviaTestCase(unittest.TestCase):
             self.assertIn('current_category', data)
             
 
-    def test_404_get_all_questions_of_cat_not_present(self):
+    def test_011_404_get_all_questions_of_cat_not_present(self):
         category_id = 100000
         res = self.client().get('/api/questions/categories/' + str(category_id))
         self.assertEqual(res.status_code, 404)
         
-    def test_get_all_categories(self):
+    def test_012_get_all_categories(self):
         res = self.client().get('/api/categories')
 
         self.assertEqual(res.status_code, 200)
@@ -157,14 +165,34 @@ class TriviaTestCase(unittest.TestCase):
             self.assertEqual(len(data['categories']), 7)
             self.assertEqual(data['categories'][0]['id'], 1)
 
-    def test_404_get_category_1(self):
+    def test_013_404_get_category_1(self):
         category_id = 1
         res = self.client().get('/api/categories/' + str(category_id))
 
         self.assertEqual(res.status_code, 404)
 
+    def test_014_post_question(self):
+        res = self.client().post('/api/questions', json=json.dumps(self.new_qst))
+        self.assertEqual(res.status_code, 200)
+        if res.status_code == 200:
+            data = json.loads(res.data)
+            self.assertIn('created', data)
 
+    def test_015_422_post_duplicate_question(self):
+        res = self.client().post('/api/questions', json=json.dumps(self.new_qst))
+        self.assertEqual(res.status_code, 422)
 
+    def test_016_400_post_question_without_answer(self):
+        q = {
+            "question": "In which Hollywood film did Michael Jordan act?"
+        }
+        res = self.client().post(
+            '/api/questions', 
+            json=json.dumps(q)
+            )
+        self.assertEqual(res.status_code, 400)
+
+    
 # Make the tests conveniently executable
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# PR Content
- [Tests](#tests)
    + [Positives](#positives)
    + [Negatives](#negatives)
- [Commits](#commits)
    + [Implement feature tests (failing)](#implement-feature-tests--failing-)
    + [Add POST `/api/questions` endpoint & Adapt tests (passing)](#add-post---api-questions--endpoint---adapt-tests--passing-)
- [Refactor](#refactor)
---
# Tests

10 min

### Positives

- [x]  test_post_question
- Request: `curl -X POST [localhost:50](http://localhost:5000)000/api/questions --data '{ "headers": {"Content-Type": "application/json"},
"body": {"question": "In which Hollywood film did Michael Jordan act?", "answer": "Space Jam", "category_id": 5, "difficulty": 3}
}'`
- Fails: `self.assertEqual(client.post('/questions', data=q).status_code, 200)`
- Passes if status_code == 200: 
`data = json.loads(res.data)
self.assertIn('created',data)`

### Negatives

- [x]  test_400_post_question_without_answer
- Request: `curl -X POST [localhost:50](http://localhost:5000)000/api/questions --data '{ "headers": {"Content-Type": "application/json"},
"body": {"question": "In which Hollywood film did Michael Jordan act?"}
}'`
- Fails: `self.assertEqual(client.post('/questions', data=q).status_code, 400)`

# Commits

### Implement feature tests (failing)

5 min

- [x]  test_post_question
- [x]  test_400_post_question_without_answer

---

### Add POST `/api/questions` endpoint & Adapt tests (passing)

90 min

- [x]  Create route
- [x]  Implement 400 error when req. params not present
- [x]  Update get_cats_and_format_response() to handle created
- [x]  pass on current_category
- [x]  Prevent duplicate insertion
- [x]  Add documentation in comment
- get_cats_and_format_response()
- create_question()
- [x]  Fix other tests
- Understand how to pass arguments to self
- understand how to ensure execution order of functions (rename with 01, 02, ..)
- [x]  Understand how to write send post requests with test client
- json= instead of data=

---

# Refactor

20 min

- [x]  re-write request.data to have question data & current_category on top-level

```python
"""Returns the database URI after prompting the user for the password. Supports only localhost.
  
  Keyword arguments:
  db_user -- user with which to access the database
  db_name -- the database name
  Return: Returns a URI-string formatted as '<RDBMS-dialect>://<db_user>:<password>@localhost:5432/<db_name>'
  """
```

- [x]  Read error message in test_422_post_duplicate_question

```python
"""
if res.status_code == 422:
            responses = [rsp.decode('utf-8') for rsp in res.response]
            self.assertIn('already present', responses[0])
"""
```