### PR TITLE
Add feature delete question

### DIFF
--- a/projects/02_trivia_api/starter/.gitignore
+++ b/projects/02_trivia_api/starter/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 venv
 env
+backend/prepare-test-db.ps1
 
 # OS generated files #
 ######################

--- a/projects/02_trivia_api/starter/backend/export-flask-vars.ps1
+++ b/projects/02_trivia_api/starter/backend/export-flask-vars.ps1
@@ -1,0 +1,1 @@
+$env:FLASK_APP="flaskr"; $env:FLASK_ENV="development"

--- a/projects/02_trivia_api/starter/backend/flaskr/__init__.py
+++ b/projects/02_trivia_api/starter/backend/flaskr/__init__.py
@@ -33,7 +33,7 @@ def paginate_result(result, page=1):
   end = min(len(result), start+QUESTIONS_PER_PAGE)
   return [result[ix].format() for ix in range(start, end)]
 
-def get_cats_and_format_response(paginated_questions=None, current_category='all', created=None):
+def get_cats_and_format_response(paginated_questions=None, current_category='all', created=None, deleted=None):
   """
   Provides the default response layout with and adds `questions` (paginated) & `created` if present:
       - success
@@ -63,6 +63,8 @@ def get_cats_and_format_response(paginated_questions=None, current_category='all
     res.update({'questions': paginated_questions})
   if created:
     res.update({'created': created})
+  if deleted:
+    res.update({'deleted': deleted})
   return res
 
 def create_app(test_config=None):

--- a/projects/02_trivia_api/starter/backend/flaskr/__init__.py
+++ b/projects/02_trivia_api/starter/backend/flaskr/__init__.py
@@ -35,13 +35,14 @@ def paginate_result(result, page=1):
 
 def get_cats_and_format_response(paginated_questions=None, current_category='all', created=None, deleted=None):
   """
-  Provides the default response layout with and adds `questions` (paginated) & `created` if present:
+  Provides the default response layout with and adds (if present) `questions` (paginated), `created` & `deleted`:
       - success
       - total_questions
       - categories
       - current_category
       - questions (optional) 
       - created (optional)
+      - deleted (optional)
 
   Arguments:
     paginated_questions {list} -- List of questions as dicts with a maximum length defined by QUESTIONS_PER_PAGE per page.]

--- a/projects/02_trivia_api/starter/backend/flaskr/__init__.py
+++ b/projects/02_trivia_api/starter/backend/flaskr/__init__.py
@@ -232,13 +232,12 @@ def create_app(test_config=None):
   def delete_question(question_id):
     try:
       to_delete = Question.query.get(question_id)
-      print(to_delete.format())
       to_delete.delete()
       return get_cats_and_format_response(deleted=to_delete.format())
-    except:
+    except AttributeError as e:
       db.session.rollback()
-      print('Rolled back. ERROR:', traceback.print_exc())
-      return 'Something went wrong:' + str(traceback.print_exc()), 422
+      print('Rolled back. AttributeError:', e)
+      return 'Resource does not exist.', 404
     finally:
       db.session.close()
     return 

--- a/projects/02_trivia_api/starter/backend/flaskr/__init__.py
+++ b/projects/02_trivia_api/starter/backend/flaskr/__init__.py
@@ -225,6 +225,20 @@ def create_app(test_config=None):
   TEST: When you click the trash icon next to a question, the question will be removed.
   This removal will persist in the database and when you refresh the page. 
   '''
+  @app.route('/api/questions/<int:question_id>', methods=['DELETE'])
+  def delete_question(question_id):
+    try:
+      to_delete = Question.query.get(question_id)
+      print(to_delete.format())
+      to_delete.delete()
+      return get_cats_and_format_response(deleted=to_delete.format())
+    except:
+      db.session.rollback()
+      print('Rolled back. ERROR:', traceback.print_exc())
+      return 'Something went wrong:' + str(traceback.print_exc()), 422
+    finally:
+      db.session.close()
+    return 
 
   '''
   @TODO: 

--- a/projects/02_trivia_api/starter/backend/test_flaskr.py
+++ b/projects/02_trivia_api/starter/backend/test_flaskr.py
@@ -201,6 +201,21 @@ class TriviaTestCase(unittest.TestCase):
             )
         self.assertEqual(res.status_code, 400)
 
+    def test_017_delete_question(self):
+        qst_id = 24
+        res = self.client().delete('/api/questions/' + str(qst_id))
+        self.assertEqual(res.status_code, 200)
+        if res.status_code == 200:
+            data = json.loads(res.data)
+            self.assertIn('deleted', data)
+
+    def test_404_delete_non_existent_question(self):
+        qst_id = 100
+        res = self.client().delete('/api/questions/' + str(qst_id))
+        self.assertEqual(res.status_code, 404)
+
+
+
     
 # Make the tests conveniently executable
 if __name__ == "__main__":

--- a/projects/02_trivia_api/starter/backend/test_flaskr.py
+++ b/projects/02_trivia_api/starter/backend/test_flaskr.py
@@ -202,14 +202,14 @@ class TriviaTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 400)
 
     def test_017_delete_question(self):
-        qst_id = 24
-        res = self.client().delete('/api/questions/' + str(qst_id))
+        to_delete = Question.query.filter(Question.question.ilike('%jordan%')).first()
+        res = self.client().delete('/api/questions/' + str(to_delete.id))
         self.assertEqual(res.status_code, 200)
         if res.status_code == 200:
             data = json.loads(res.data)
             self.assertIn('deleted', data)
 
-    def test_404_delete_non_existent_question(self):
+    def test_018_404_delete_non_existent_question(self):
         qst_id = 100
         res = self.client().delete('/api/questions/' + str(qst_id))
         self.assertEqual(res.status_code, 404)


### PR DESCRIPTION
# PR Content
- [Tests](#tests)
    + [Positives](#positives)
    + [Negatives](#negatives)
- [Commits](#commits)
    + [Implement feature tests (failing)](#implement-feature-tests--failing-)
    + [Add DELETE `/api/questions/<int:qst_id>` endpoint](#add-delete---api-questions--int-qst-id---endpoint)
    + [Update response_formatter (tests passing)](#update-response-formatter--tests-passing-)
    + [Add test (passing)](#add-test--passing-)
    + [Update DELETE `/api/questions/<id>`endpoint](#update-delete---api-questions--id--endpoint)
- [Refactor](#refactor)
---
# Tests

5 min

### Positives

- [x]  test_delete_question
- Request: `curl -X DELETE localhost:5000/api/questions/24`
- Fails: `self.assertEqual(client.delete('/api/questions/24').status_code, 200)`
- Passes if status_code == 200: `self.assertIn('deleted',data)`

### Negatives

- [x]  test_404_delete_non_existent_question
- Request: `curl -X DELETE localhost:5000/api/questions/100`
- Passes: `self.assertEqual(client.delete('/api/questions/24').status_code, 404)`

# Commits

### Implement feature tests (failing)

5 min

- [x]  test_delete_question
- [x]  test_404_delete_non_existent_question

---

### Add DELETE `/api/questions/<int:qst_id>` endpoint

10 min

- [x]  Add endpoint
- pass on qst_id
- allow method
- try/except/finally on get
- return response_formatter

---

### Update response_formatter (tests passing)

5 min

- [x]  Add "deleted" as arg & update dict
- [x]  Update documentation

---

### Add test (passing)

15 min

- [x]  Longer to do:
- Create something
- define something
- [ ]  Outstanding to do

---

### Update DELETE `/api/questions/<id>`endpoint

5 min

- [x]  Catch AttributeError in case id wasn't found in DB

# Refactor

30 min

- [x]  Write bash script to drop, create & restore db on Windows

    ```bash
    dropdb -U postgres trivia_test
    createdb -U postgres trivia_test
    psql -U postgres -d trivia_test -a -f .\backend\trivia.psql
    ```

    **Solution:** `/backend/prepare-test-db.ps1`

    ```bash
    $env:PGPASSWORD='XXXXXX'; dropdb trivia_test; createdb trivia_test; psql -U postgres -d trivia_test -a -f .\backend\trivia.psql
    ```

- [x]  Write bash script to export flask environment variables on Windows

    ```bash
    $env:FLASK_APP="flaskr"
    $env:FLASK_ENV="development"
    ```

    **Solution:** `export-flask-vars.ps1`

    ```bash
    $env:FLASK_APP="flaskr"; $env:FLASK_ENV="development"
    ```