### PR TITLE
Add feat post search (question & category)

### DIFF
--- a/projects/02_trivia_api/starter/backend/flaskr/__init__.py
+++ b/projects/02_trivia_api/starter/backend/flaskr/__init__.py
@@ -63,7 +63,7 @@ def get_cats_and_format_response(paginated_questions=None, current_category='all
   }
   if total_questions is None:
     res.update({'total_questions': len(Question.query.all())})
-  if paginated_questions:
+  if paginated_questions is not None:
     res.update({'questions': paginated_questions})
   if created:
     res.update({'created': created})

--- a/projects/02_trivia_api/starter/backend/test_flaskr.py
+++ b/projects/02_trivia_api/starter/backend/test_flaskr.py
@@ -229,7 +229,7 @@ class TriviaTestCase(unittest.TestCase):
             "search_term": "afkhbfkbfkjbfiubfifbu"
             , "search_on_answer": True
         })
-        res = self.client().post('/api/quesitons/searches', json=search)
+        res = self.client().post('/api/questions/searches', json=search)
 
         self.assertEqual(res.status_code, 200)
         if res.status_code == 200:

--- a/projects/02_trivia_api/starter/backend/test_flaskr.py
+++ b/projects/02_trivia_api/starter/backend/test_flaskr.py
@@ -223,7 +223,7 @@ class TriviaTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         if res.status_code == 200:
             data = json.loads(res.data)
-            self.assertEqual(len(data['questions']), 17)
+            self.assertEqual(data['total_questions'], 17)
     def test_020_search_question_without_result(self):
         search = json.dumps({
             "search_term": "afkhbfkbfkjbfiubfifbu"
@@ -246,7 +246,7 @@ class TriviaTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         if res.status_code == 200:
             data = json.loads(res.data)
-            self.assertEqual(len(data['questions']), 13)
+            self.assertEqual(data['total_questions'], 13)
     
     def test_022_search_question_on_qst(self):
         search = json.dumps({
@@ -257,7 +257,7 @@ class TriviaTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         if res.status_code == 200:
             data = json.loads(res.data)
-            self.assertEqual(len(data['categories']), 6)
+            self.assertEqual(data['total_categories'], 6)
 
     def test_023_400_search_without_term(self):
         res = self.client().post('/api/questions/searches')

--- a/projects/02_trivia_api/starter/backend/test_flaskr.py
+++ b/projects/02_trivia_api/starter/backend/test_flaskr.py
@@ -213,6 +213,61 @@ class TriviaTestCase(unittest.TestCase):
         qst_id = 100
         res = self.client().delete('/api/questions/' + str(qst_id))
         self.assertEqual(res.status_code, 404)
+    
+    def test_019_search_question_on_qst(self):
+        search = json.dumps({
+            "search_term": "a"
+        })
+        res = self.client().post('/api/questions/searches', json=search)
+
+        self.assertEqual(res.status_code, 200)
+        if res.status_code == 200:
+            data = json.loads(res.data)
+            self.assertEqual(len(data['questions']), 17)
+    def test_020_search_question_without_result(self):
+        search = json.dumps({
+            "search_term": "afkhbfkbfkjbfiubfifbu"
+            , "search_on_answer": True
+        })
+        res = self.client().post('/api/quesitons/searches', json=search)
+
+        self.assertEqual(res.status_code, 200)
+        if res.status_code == 200:
+            data = json.loads(res.data)
+            self.assertEqual(len(data['questions']), 0)
+
+    def test_021_search_question_on_qst(self):
+        search = json.dumps({
+            "search_term": "a"
+            , "search_on_answer": True
+        })
+        res = self.client().post('/api/questions/searches', json=search)
+
+        self.assertEqual(res.status_code, 200)
+        if res.status_code == 200:
+            data = json.loads(res.data)
+            self.assertEqual(len(data['questions']), 13)
+    
+    def test_022_search_question_on_qst(self):
+        search = json.dumps({
+            "search_term": "a"
+        })
+        res = self.client().post('/api/categories/searches', json=search)
+
+        self.assertEqual(res.status_code, 200)
+        if res.status_code == 200:
+            data = json.loads(res.data)
+            self.assertEqual(len(data['categories']), 6)
+
+    def test_023_400_search_without_term(self):
+        res = self.client().post('/api/questions/searches')
+
+        self.assertEqual(res.status_code, 400)
+    def test_024_405_get_search(self):
+        res = self.client().get('/api/questions/searches')
+
+        self.assertEqual(res.status_code, 405)
+    
 
 
 

--- a/projects/02_trivia_api/starter/backend/test_flaskr.py
+++ b/projects/02_trivia_api/starter/backend/test_flaskr.py
@@ -236,7 +236,7 @@ class TriviaTestCase(unittest.TestCase):
             data = json.loads(res.data)
             self.assertEqual(len(data['questions']), 0)
 
-    def test_021_search_question_on_qst(self):
+    def test_021_search_question_on_ans(self):
         search = json.dumps({
             "search_term": "a"
             , "search_on_answer": True
@@ -246,9 +246,9 @@ class TriviaTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         if res.status_code == 200:
             data = json.loads(res.data)
-            self.assertEqual(data['total_questions'], 13)
+            self.assertEqual(data['total_questions'], 14)
     
-    def test_022_search_question_on_qst(self):
+    def test_022_search_category(self):
         search = json.dumps({
             "search_term": "a"
         })

--- a/projects/02_trivia_api/starter/backend/test_flaskr.py
+++ b/projects/02_trivia_api/starter/backend/test_flaskr.py
@@ -257,7 +257,7 @@ class TriviaTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         if res.status_code == 200:
             data = json.loads(res.data)
-            self.assertEqual(data['total_categories'], 6)
+            self.assertEqual(data['total_categories'], 4)
 
     def test_023_400_search_without_term(self):
         res = self.client().post('/api/questions/searches')


### PR DESCRIPTION
# PR Contents
- [Tests](#tests)
    + [Positives](#positives)
    + [Negatives](#negatives)
- [Commits](#commits)
    + [Implement feature tests (failing)](#implement-feature-tests--failing-)
    + [Add POST `/api/questions/searches` (tests failing)](#add-post---api-questions-searches---tests-failing-)
    + [Update response formatter](#update-response-formatter)
    + [Add POST `/api/categories/searches` (tests passing)](#add-post---api-categories-searches---tests-passing-)
- [Refactor](#refactor)
---
# Tests

20 min

### Positives

- [x]  test_019_search_question_on_qst
- Request: `curl -X POST localhost:5000/api/questions/searches`
- Fails:
`a = {"search_term": "a", "search_on_answer": True}` 
`self.assertEqual(client.post('/api/questions/searches', json=search).status_code, 200)`
- Passes if status_code == 200: `self.assertEqual(len(questions), 17)`
- [x]  test_020_search_question_without_result
- Request: `curl -X POST localhost:5000/api/questions/searches`
- Fails:
`a = {"search_term": "afkjbnefkbskjbfek", "search_on": "question"}` 
`self.assertEqual(client.post('/api/questions/searches', json=search).status_code, 200)`
- Passes if status_code == 200: `self.assertEqual(len(questions), 0)`
- [x]  test_021_search_question_on_ans
- Request: `curl -X POST localhost:5000/api/questions/searches`
- Fails: 
`a = {"search_term": "a", "search_on": "answer"}`
`self.assertEqual(client.post('/api/questions/searches', json=search).status_code, 200)`
- Passes if status_code == 200: `self.assertEqual(len(questions), 13)`
- [x]  test_022_search_category
- Request: `curl -X POST localhost:5000/api/questions/searches`
- Fails: 
`a = {"search_term": "a", "search_on": "category"}`
`self.assertEqual(client.post('/api/categories/searches', json=search).status_code, 200)`
- Passes if status_code == 200: `self.assertEqual(len(questions), 6)`

### Negatives

- [x]  test_023_400_search_without_term
- Request: `curl -X POST localhost:5000/api/questions/searches`
- Fails:
`self.assertEqual(client.post('/api/questions/searches').status_code, 400)`
- [x]  test_024_405_get_search
- Request: `curl -X GET localhost:5000/api/questions/searches`
- Fails:
`self.assertEqual(client.get('/api/questions/searches').status_code, 405)`

# Commits

### Implement feature tests (failing)

25 min

- [x]  test_019_search_question_on_qst
- [x]  test_020_search_question_without_result
- [x]  test_021_search_question_on_ans
- [x]  test_022_search_category
- [x]  test_023_400_search_without_term
- [x]  test_024_405_get_search

---

### Add POST `/api/questions/searches` (tests failing)

20 min

- [x]  include search params:
- str:search_term *
- bool:search_on_answer='question' (optional) (alternatively: 'answer')
- [x]  Create POST endpoint for `/api/questions/searches`
- accept POST method only
- parse json data
- check if search_term present (return 400 if not)
- query results based on 'search_on' (empty [] if nothing found)
- return response_format

---

### Update response formatter

20 min

- [x]  Update func
- search_term
- total_questions optional (for search)
- [x]  Update doc
- [x]  Update tests

---

### Add POST `/api/categories/searches` (tests passing)

20 min

- [x]  include search params:
- str:search_term *
- [x]  Create POST endpoint for `/api/questions/searches`
- accept POST method only
- parse json data
- check if search_term present (return 400 if not)
- query results (empty [] if nothing found)
- return response_format
- [x]  Update response formatter
- [x]  Update test

---

# Refactor